### PR TITLE
Backport content length fix

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectAggregator.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectAggregator.java
@@ -16,6 +16,7 @@
 package io.netty.handler.codec.http;
 
 import static io.netty.handler.codec.http.HttpHeaders.is100ContinueExpected;
+import static io.netty.handler.codec.http.HttpHeaders.isContentLengthSet;
 import static io.netty.handler.codec.http.HttpHeaders.removeTransferEncodingChunked;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.CompositeByteBuf;
@@ -209,7 +210,7 @@ public class HttpObjectAggregator extends MessageToMessageDecoder<HttpObject> {
                 // See rfc2616 14.13 Content-Length
                 if (!isContentLengthSet(currentMessage)) {
                     currentMessage.headers().set(
-                            Names.CONTENT_LENGTH,
+                            HttpHeaders.Names.CONTENT_LENGTH,
                             String.valueOf(content.readableBytes()));
                 }
                 // All done

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectAggregator.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectAggregator.java
@@ -201,11 +201,17 @@ public class HttpObjectAggregator extends MessageToMessageDecoder<HttpObject> {
                     currentMessage.headers().add(trailer.trailingHeaders());
                 }
 
-                // Set the 'Content-Length' header.
-                currentMessage.headers().set(
-                        HttpHeaders.Names.CONTENT_LENGTH,
-                        String.valueOf(content.readableBytes()));
-
+                // Set the 'Content-Length' header. If one isn't already set.
+                // This is important as HEAD responses will use a 'Content-Length' header which
+                // does not match the actual body, but the number of bytes that would be
+                // transmitted if a GET would have been used.
+                //
+                // See rfc2616 14.13 Content-Length
+                if (!isContentLengthSet(currentMessage)) {
+                    currentMessage.headers().set(
+                            Names.CONTENT_LENGTH,
+                            String.valueOf(content.readableBytes()));
+                }
                 // All done
                 out.add(currentMessage);
             }


### PR DESCRIPTION
Backport the fix for content-length being set in response to a HEAD request. The only change I made on top of it was to fix up imports.

@katfang please review / merge

Note that merge is into our 4.0.8 branch
